### PR TITLE
Raise error for invalid paths

### DIFF
--- a/spec/baked_file_system_spec.cr
+++ b/spec/baked_file_system_spec.cr
@@ -64,6 +64,15 @@ describe BakedFileSystem do
     file.write_to_io(io, compressed: false).should be_nil
     io.size.should eq(sz)
   end
+
+  it "raises if path does not contain entries" do
+    expect_raises Exception, "BakedFileSystem empty" do
+      Storage.register_files_from_loader("\n", "storage/empty", false)
+    end
+  end
+  it "allows empty if path does not contain entries" do
+    Storage.register_files_from_loader("\n", "storage/empty", true)
+  end
 end
 
 def read_slice(path)

--- a/spec/loader_spec.cr
+++ b/spec/loader_spec.cr
@@ -1,0 +1,10 @@
+require "./spec_helper"
+require "../src/loader/loader"
+
+describe BakedFileSystem::Loader do
+  it "raises if path does not exist" do
+    expect_raises BakedFileSystem::Loader::Error, "path does not exist" do
+      BakedFileSystem::Loader.load(File.expand_path(File.join(__DIR__, "invalid_path")))
+    end
+  end
+end

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -94,6 +94,7 @@ module BakedFileSystem
   end
 
   macro load(path, dir = __DIR__)
+    {% raise "BakedFileSystem.load expects `path` to be a StringLiteral." unless path.is_a?(StringLiteral) %}
     extend BakedFileSystem
 
     @@files = [] of BakedFileSystem::BakedFile

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -93,6 +93,9 @@ module BakedFileSystem
     @@files
   end
 
+  # Creates a baked file system and loads contents of files in *path*.
+  # If *path* is relative, it will be based on *dir* which defaults to `__DIR__`.
+  # It will raise if there are no files found in *path* unless *allow_empty* is set to `true`.
   macro load(path, dir = __DIR__, allow_empty = false)
     {% raise "BakedFileSystem.load expects `path` to be a StringLiteral." unless path.is_a?(StringLiteral) %}
     extend BakedFileSystem

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -2,7 +2,18 @@ require "base64"
 
 module BakedFileSystem
   module Loader
+    class Error < Exception
+    end
+
     def self.load(root_path)
+      if !File.exists?(root_path)
+        raise Error.new "path does not exist: #{root_path}"
+      elsif !File.directory?(root_path)
+        raise Error.new "path is not a directory: #{root_path}"
+      elsif !File.readable?(root_path)
+        raise Error.new "path is not readable: #{root_path}"
+      end
+
       root_path_length = root_path.size
 
       result = [] of String
@@ -10,6 +21,10 @@ module BakedFileSystem
       files = Dir.glob(File.join(root_path, "**", "*"))
                  # Reject hidden entities and directories
                  .reject { |path| File.directory?(path) || !(path =~ /(\/\..+)/).nil? }
+
+      if files.empty?
+        raise Error.new "no files found: #{root_path}"
+      end
 
       files.each do |path|
         # encoded_path,encoded_mime_type,size,compressed_size,urlsafe_encoded_gzipped_content

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -22,10 +22,6 @@ module BakedFileSystem
                  # Reject hidden entities and directories
                  .reject { |path| File.directory?(path) || !(path =~ /(\/\..+)/).nil? }
 
-      if files.empty?
-        raise Error.new "no files found: #{root_path}"
-      end
-
       files.each do |path|
         # encoded_path,encoded_mime_type,size,compressed_size,urlsafe_encoded_gzipped_content
         entity = [] of String


### PR DESCRIPTION
Closes #4 

This requires crystal-lang/crystal#4614  to properly show the error messages from macro run.
But the next Crystal release 0.24 should arrive shortly.

Output looks like this:
```
Error in line 1: while requiring "./failing-test.cr"

in failing-test.cr:10: expanding macro

      BakedFileSystem.load("./invalid_path", __DIR__)
                      ^~~~

in src/baked_file_system.cr:102: Error executing run (exit code: 1): ./loader "./invalid_path" "/test/crystal/baked_file_system"

stderr:

    directory /test/crystal/baked_file_system/invalid_path does not exist (Exception)
      from ???
      from ???
      from __crystal_main
      from main
      from __libc_start_main
      from ???
      from ???



    source = {{ run("./loader", path, source).stringify }}
```