### PR TITLE
Use byte encoding as Crystal string instead of Base64

### DIFF
--- a/spec/baked_file_system_spec.cr
+++ b/spec/baked_file_system_spec.cr
@@ -13,13 +13,13 @@ describe BakedFileSystem do
     baked_file = Storage.get("images/sidekiq.png")
     baked_file.name.should eq("sidekiq.png")
     baked_file.size.should eq(52949)
-    baked_file.compressed_size.should eq(47883)
+    baked_file.compressed_size.should be_close 47883, 40
     baked_file.mime_type.should eq("image/png")
 
     baked_file = Storage.get("/lorem.txt")
     baked_file.name.should eq("lorem.txt")
     baked_file.size.should eq(669)
-    baked_file.compressed_size.should eq(400)
+    baked_file.compressed_size.should be_close 400, 12
     baked_file.mime_type.should eq("text/plain")
   end
 

--- a/spec/baked_file_system_spec.cr
+++ b/spec/baked_file_system_spec.cr
@@ -64,15 +64,6 @@ describe BakedFileSystem do
     file.write_to_io(io, compressed: false).should be_nil
     io.size.should eq(sz)
   end
-
-  it "raises if path does not contain entries" do
-    expect_raises Exception, "BakedFileSystem empty" do
-      Storage.register_files_from_loader("\n", "storage/empty", false)
-    end
-  end
-  it "allows empty if path does not contain entries" do
-    Storage.register_files_from_loader("\n", "storage/empty", true)
-  end
 end
 
 def read_slice(path)

--- a/spec/loader_spec.cr
+++ b/spec/loader_spec.cr
@@ -4,7 +4,7 @@ require "../src/loader/loader"
 describe BakedFileSystem::Loader do
   it "raises if path does not exist" do
     expect_raises BakedFileSystem::Loader::Error, "path does not exist" do
-      BakedFileSystem::Loader.load(File.expand_path(File.join(__DIR__, "invalid_path")))
+      BakedFileSystem::Loader.load(IO::Memory.new, File.expand_path(File.join(__DIR__, "invalid_path")))
     end
   end
 end

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -102,25 +102,10 @@ module BakedFileSystem
 
     @@files = [] of BakedFileSystem::BakedFile
 
-    register_files_from_loader {{ run("./loader", path, dir).stringify }}, File.expand_path({{ path }}, {{ dir }}), {{ allow_empty }}
-  end
+    {{ run("./loader", path, dir) }}
 
-  # :nodoc:
-  def register_files_from_loader(source, path, allow_empty)
-    if source.size > 1
-      source.each_line do |line|
-        parts = line.split("|")
-
-        @@files << BakedFileSystem::BakedFile.new(
-          path:            parts[0],
-          mime_type:       parts[1],
-          size:            parts[2].to_i32,
-          compressed_size: parts[3].to_i32,
-          encoded:         parts[4].strip
-        )
-      end
-    elsif !allow_empty
-      raise "BakedFileSystem empty: no files in #{path}"
-    end
+    {% unless allow_empty %}
+    raise "BakedFileSystem empty: no files in #{File.expand_path({{ path }}, {{ dir }})}" if @@files.size == 0
+    {% end %}
   end
 end

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -7,17 +7,18 @@ module BakedFileSystem
   end
 
   struct BakedFile
-    getter! name : String
-    getter! path : String
-    getter! mime_type : String
-    getter! size : Int32
-    getter! encoded : String
-    getter! compressed_size : Int32
+    getter name : String
+    getter path : String
+    getter mime_type : String
+    getter size : Int32
+    getter encoded : String
+    getter compressed_size : Int32
 
     @slice : Slice(UInt8)?
     @io : IO?
 
-    def initialize(@path, @mime_type, @size, @compressed_size, @encoded)
+    def initialize(@path, @mime_type, @size, @encoded)
+      @compressed_size = @encoded.bytesize
       @name = File.basename(path)
     end
 
@@ -64,7 +65,7 @@ module BakedFileSystem
     end
 
     private def _to_slice
-      @slice ||= Base64.decode(encoded)
+      @slice ||= encoded.to_slice
     end
 
     private def _decompress_to_io(io)

--- a/src/loader.cr
+++ b/src/loader.cr
@@ -1,4 +1,5 @@
 require "./loader/*"
 
 path = File.expand_path(ARGV[0], ARGV[1])
-puts BakedFileSystem::Loader.load(path)
+
+BakedFileSystem::Loader.load(STDOUT, path)


### PR DESCRIPTION
Crystal allows to put arbitrary byte values into strings even if they aren't valid UTF-8.

This is 30% more space-efficient than Base64 encoding which translates directly to the size of the compiled binary.

Unfortunately there exists no literal for Slice right now (but there is a discussion about this in crystal-lang/crystal#2886) so we need to resort to strings for this. It is a bit hacky but look like it works 👍 

It also includes a refactoring of the API exposed by `BakedFile`, including making it an `IO` and deprecating several methods that can be replaced by using the file as an `IO`.

Based on #11