### PR TITLE
Remove BakedFile#slice getter

### DIFF
--- a/spec/baked_file_system_spec.cr
+++ b/spec/baked_file_system_spec.cr
@@ -74,6 +74,6 @@ describe BakedFileSystem do
   end
 
   it "handles interpolation in content" do
-    String.new(Storage.get("string_encoding/interpolation.gz").slice).should eq "\#{foo} \{% macro %}\n"
+    String.new(Storage.get("string_encoding/interpolation.gz").to_slice).should eq "\#{foo} \{% macro %}\n"
   end
 end

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -45,12 +45,11 @@ module BakedFileSystem
 
     # Returns the size of this virtual file.
     getter size : Int32
-    getter slice : Bytes
 
     # Returns whether this file is compressed. If not, it is decompressed on read.
     getter? compressed : Bool
 
-    def initialize(@path, @mime_type, @size, @compressed, @slice)
+    def initialize(@path, @mime_type, @size, @compressed, @slice : Bytes)
       @memory_io = IO::Memory.new(@slice)
       @wrapped_io = compressed? ? @memory_io : Gzip::Reader.new(@memory_io)
     end


### PR DESCRIPTION
The instance variable `@slice` shouldn't be exposed directly. There is already `#to_slice` which implements a more natural interface, similar to other Crystal types.