### PR TITLE
Remove BakedFile#name

### DIFF
--- a/spec/baked_file_system_spec.cr
+++ b/spec/baked_file_system_spec.cr
@@ -19,13 +19,11 @@ describe BakedFileSystem do
 
   it "get correct file attributes" do
     baked_file = Storage.get("images/sidekiq.png")
-    baked_file.name.should eq("sidekiq.png")
     baked_file.size.should eq(52949)
     baked_file.compressed_size.should be_close 47883, 40
     baked_file.mime_type.should eq("image/png")
 
     baked_file = Storage.get("/lorem.txt")
-    baked_file.name.should eq("lorem.txt")
     baked_file.size.should eq(669)
     baked_file.compressed_size.should be_close 400, 12
     baked_file.mime_type.should eq("text/plain")

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -54,10 +54,6 @@ module BakedFileSystem
       @wrapped_io = compressed? ? @memory_io : Gzip::Reader.new(@memory_io)
     end
 
-    def name
-      File.basename(path)
-    end
-
     def read(slice : Bytes)
       @wrapped_io.read(slice)
     end


### PR DESCRIPTION
There's no need to make the base name of a file directly accessible. Calls to this method can be easily replaced by `File.basename(baked_file.path)`.