### PR TITLE
Refactor creation of a baked file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/schovi/baked_file_system.svg?branch=master)](https://travis-ci.org/schovi/baked_file_system)
 
-Include (bake them) static files into your binary and access them anytime you need.
+Include (bake them) static files into a binary at compile time and access them anytime you need.
 
 ## Installation
 
@@ -15,47 +15,37 @@ dependencies:
     github: schovi/baked_file_system
 ```
 
-
 ## Usage
 
-Load library with:
+A custom type that extends `BakedFileSystem` is used as a file system. The macro `bake_folder` bakes all files in
+a given path into the virtual file system. Both relative and absolute paths are supported, as well as baking multiple
+folders.
 
 ```crystal
 require "baked_file_system"
 
-```
-
-Load folder with absolute path
-
-```crystal
 class FileStorage
-  BakedFileSystem.load("/home/my_name/work/crystal_project/public")
-end
-```
+  extend BakedFileSystem
 
-Better and more often usage will be, when you need to locate files in your repository
-That repository can be in different locations (imagine more ppl working on same program)
-
-```crystal
-class FileStorage
-  BakedFileSystem.load("../public")
+  bake_folder "/home/my_name/work/crystal_project/public"
+  bake_folder "../public"
 end
 
 ```
 
-And finally how to get files from that storage
+Files can be loaded using `get` and `get?` class methods.
 
 ```crystal
 file = FileStorage.get("path/to/file.png")
 
-file.gets    # returns content of file
-file.path    # returns path of file
+file.gets_to_end  # returns content of file
+file.path         # returns path of file
 file.mime_type    # returns mime type
-file.size    # returns size of original file
+file.size         # returns size of original file
 ```
 
-When try to get missing file, `BakedFileSystem.get` raises a `BakedFileSystem::NoSuchFileError` exception
-while `BakedFileSystem.get?` returns `nil`.
+When try to get missing file, `get` raises a `BakedFileSystem::NoSuchFileError` exception
+while `get?` returns `nil`.
 
 ```crystal
 begin

--- a/spec/baked_file_system_spec.cr
+++ b/spec/baked_file_system_spec.cr
@@ -1,7 +1,24 @@
 require "./spec_helper"
 
 class Storage
-  BakedFileSystem.load("./storage")
+  extend BakedFileSystem
+  bake_folder "./storage"
+end
+
+class ManualStorage
+  extend BakedFileSystem
+  bake_file "hello-world.txt", "Hello World\n"
+end
+
+class MutlipleStorage
+  extend BakedFileSystem
+  bake_folder "./storage"
+
+  it "raises for empty folder" do
+    expect_raises(Exception, "no files in") do
+      bake_folder "./empty_storage"
+    end
+  end
 end
 
 def read_slice(path)
@@ -33,6 +50,7 @@ describe BakedFileSystem do
     expect_raises(BakedFileSystem::NoSuchFileError) do
       Storage.get("missing.file")
     end
+    Storage.get?("missing.file").should be_nil
   end
 
   it "can read file contents" do
@@ -73,5 +91,13 @@ describe BakedFileSystem do
 
   it "handles interpolation in content" do
     String.new(Storage.get("string_encoding/interpolation.gz").to_slice).should eq "\#{foo} \{% macro %}\n"
+  end
+
+  describe ManualStorage do
+    it do
+      file = ManualStorage.get("hello-world.txt")
+      file.size.should eq 12
+      file.gets_to_end.should eq "Hello World\n"
+    end
   end
 end

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -171,4 +171,8 @@ module BakedFileSystem
     raise "BakedFileSystem empty: no files in #{File.expand_path({{ path }}, {{ dir }})}" if @@files.size == 0
     {% end %}
   end
+
+  def bake_file(file : BakedFile)
+    @@files << file
+  end
 end

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -25,7 +25,7 @@ module BakedFileSystem
                  .reject { |path| File.directory?(path) || !(path =~ /(\/\..+)/).nil? }
 
       files.each do |path|
-        io << "@@files << BakedFileSystem::BakedFile.new(\n"
+        io << "bake_file BakedFileSystem::BakedFile.new(\n"
         io << "  path:            " << path[root_path_length..-1].dump << ",\n"
         io << "  mime_type:       " << (mime_type(path) || `file -b --mime-type #{path}`.strip).dump << ",\n"
         io << "  size:            " << File.stat(path).size << ",\n"


### PR DESCRIPTION
Prior to this PR you would create a custom type and call `BakedFileSystem.load(path)` from that types scope. This would extend `BakedFileSystem` and add baked files (created from local folder *path*) to the file system.

With this PR, you need to exlicitly extend the custom type from `BakedFileSystem`. This extension adds macros and class methods for baking a folder or a specific file to the type scope:

```crystal
# previously:
class MyFileSystem
  BakedFileSystem.load("path/to/folder")
end
# now:
class MyFileSystem
  extend BakedFileSystem
  bake_folder "path/to/folder"
end
```
This is a breaking change, but IMHO it's very much worth it. It allows adding files from multiple folders and as well custom `BakedFile` instances using `bake_file`. While being a bit more characters, it makes it explicit that `MyFileSystem`  extends `BakedFileSystem` - which was previously hidden by `BakedFileSystem.load`. This makes things more transparent.
