### PR TITLE
Update to Crystal 0.25.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,6 @@
 name: baked_file_system
 version: 0.9.5
+crystal: 0.25.0
 
 authors:
   - David Schovanec <david@schovi.cz>

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -28,7 +28,7 @@ module BakedFileSystem
         io << "bake_file BakedFileSystem::BakedFile.new(\n"
         io << "  path:            " << path[root_path_length..-1].dump << ",\n"
         io << "  mime_type:       " << (mime_type(path) || `file -b --mime-type #{path}`.strip).dump << ",\n"
-        io << "  size:            " << File.stat(path).size << ",\n"
+        io << "  size:            " << File.info(path).size << ",\n"
         compressed = path.ends_with?("gz")
 
         io << "  compressed:      " << compressed << ",\n"


### PR DESCRIPTION
This change replaces `File.stat` with `File.info`. It is incompatible with 0.24.2 (thus CI fails) and should be merged when 0.25.0 is publicly available.

The edit to `shard.yml` is not required, but I think it makes sense to document the targeted Crystal version.