### PR TITLE
Add missing return types to overrides of abstract methods

### DIFF
--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -63,7 +63,7 @@ module BakedFileSystem
       @slice.bytesize
     end
 
-    def write(slice : Bytes)
+    def write(slice : Bytes) : Nil
       raise "Can't write to BakedFileSystem::BakedFile"
     end
 

--- a/src/loader/string_encoder.cr
+++ b/src/loader/string_encoder.cr
@@ -17,7 +17,7 @@ class BakedFileSystem::StringEncoder < IO
     raise "Can't read from StringEncoder"
   end
 
-  def write(slice : Bytes)
+  def write(slice : Bytes) : Nil
     slice.each do |byte|
       case byte
       when 34_u8, 35_u8, 92_u8, 123_u8


### PR DESCRIPTION
This prepares for the upcoming checks in Crystal 0.30.0 (see crystal-lang/crystal#7956).