### PR TITLE
Migrate to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,30 @@
+name: Baked File System CI
+
+on: push
+
+jobs:
+  latest:
+    runs-on: ubuntu-latest
+
+    container:
+      image: crystallang/crystal:latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: shards install
+    - name: Run tests
+      run: crystal spec
+
+  nightly:
+    runs-on: ubuntu-latest
+
+    container:
+      image: crystallang/crystal:nightly
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: shards install
+    - name: Run tests
+      run: crystal spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: crystal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Baked File System
 
-[![Build Status](https://travis-ci.org/schovi/baked_file_system.svg?branch=master)](https://travis-ci.org/schovi/baked_file_system)
-
 Include (bake them) static files into a binary at compile time and access them anytime you need.
 
 ## Installation


### PR DESCRIPTION
Travis seems to be broken and it is a nice opportunity to migrate to Github actions which are more open-source friendly.