### PR TITLE
Fix "BakedFileSystem empty: no files" error on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+spec/**/* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-spec/**/* text eol=lf
+* text eol=lf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: Baked File System CI
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,28 +3,27 @@ name: Baked File System CI
 on: push
 
 jobs:
-  latest:
-    runs-on: ubuntu-latest
+  test:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        crystal: [latest, nightly]
 
-    container:
-      image: crystallang/crystal:latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: shards install
-    - name: Run tests
-      run: crystal spec
-
-  nightly:
-    runs-on: ubuntu-latest
-
-    container:
-      image: crystallang/crystal:nightly
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: shards install
-    - name: Run tests
-      run: crystal spec
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+          
+      - name: Download source
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: shards install
+
+      - name: Run tests
+        run: crystal spec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        crystal: [latest, nightly]
-
+        include:
+          - { os: ubuntu-latest, crystal: latest }
+          - { os: ubuntu-latest, crystal: nightly }
+          - { os: macos-latest }
+          - { os: windows-latest }
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -18,7 +20,7 @@ jobs:
         uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{ matrix.crystal }}
-          
+
       - name: Download source
         uses: actions/checkout@v3
 

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -20,13 +20,13 @@ module BakedFileSystem
 
       result = [] of String
 
-      files = Dir.glob(File.join(root_path, "**", "*"))
+      files = Dir.glob(Path[root_path, "**", "*"].to_posix)
                  # Reject hidden entities and directories
                  .reject { |path| File.directory?(path) || !(path =~ /(\/\..+)/).nil? }
 
       files.each do |path|
         io << "bake_file BakedFileSystem::BakedFile.new(\n"
-        io << "  path:            " << path[root_path_length..-1].dump << ",\n"
+        io << "  path:            " << Path[path].relative_to(root_path).to_posix.to_s.dump << ",\n"
         io << "  size:            " << File.info(path).size << ",\n"
         compressed = path.ends_with?("gz")
 

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -20,13 +20,13 @@ module BakedFileSystem
 
       result = [] of String
 
-      files = Dir.glob(Path[root_path, "**", "*"].to_posix)
+      files = Dir.glob(Path[root_path].to_posix.join("**", "*"))
                  # Reject hidden entities and directories
                  .reject { |path| File.directory?(path) || !(path =~ /(\/\..+)/).nil? }
 
       files.each do |path|
         io << "bake_file BakedFileSystem::BakedFile.new(\n"
-        io << "  path:            " << Path[path].relative_to(root_path).to_posix.to_s.dump << ",\n"
+        io << "  path:            " << Path[path[root_path_length..]].to_posix.to_s.dump << ",\n"
         io << "  size:            " << File.info(path).size << ",\n"
         compressed = path.ends_with?("gz")
 


### PR DESCRIPTION
Not sure if you are taking contributions, but here's my fix for #47 :sweat_smile: 

As [mentioned in the issue](https://github.com/schovi/baked_file_system/issues/47#issuecomment-1555256482), the main problem is Windows using the "wrong" path separator compared to what is expected by [Dir.glob](https://crystal-lang.org/api/1.8.2/Dir.html#glob%28%2Apatterns%3APath%7CString%2Cmatch_hidden%3Dfalse%2Cfollow_symlinks%3Dfalse%2C%26block%3AString-%3E_%29-class-method), and within `baked_file_system`.

To fix this, I just call `.to_posix` in the two places it's needed. Not sure if this the best way of handling it (possibly `baked_file_system` should accept both path separators when calling `.get` etc?) but it seems to work with what I've tested it with.

I've also added a `.gitattributes` file to ensure Git doesn't change the line endings when checking out the tests, as some of them check for the [exact size in bytes](https://github.com/schovi/baked_file_system/blob/master/spec/baked_file_system_spec.cr#LL43C22-L43C22) of baked files

Lastly, I updated the Github Actions workflow to include both Windows and Mac.