### PR TITLE
feat(bake_folder): add include_hidden option to support dot files and folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ class FileStorage
   extend BakedFileSystem
 
   bake_folder "/home/my_name/work/crystal_project/public"
-  bake_folder "../public", include_dotfiles: true # optionally includes dotfiles
+  bake_folder "../public", include_dotfiles: true
 end
 
 ```
@@ -38,6 +38,7 @@ Files can be loaded using `get` and `get?` class methods.
 
 ```crystal
 file = FileStorage.get("path/to/file.png")
+
 file.gets_to_end  # returns content of file
 file.path         # returns path of file
 file.size         # returns size of original file
@@ -52,6 +53,7 @@ begin
 rescue BakedFileSystem::NoSuchFileError
   puts "File #{path} is missing"
 end
+
 FileStorage.get? "missing/file" # => nil
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A custom type that extends `BakedFileSystem` is used as a file system. The macro
 a given path into the virtual file system. Both relative and absolute paths are supported, as well as baking multiple
 folders.
 
+You can control whether dotfiles files and folders (those starting with a dot, like `.gitignore` or `.hidden/`) are included using the `include_dotfiles` option (default: `false`).
+
 ```crystal
 require "baked_file_system"
 
@@ -27,7 +29,7 @@ class FileStorage
   extend BakedFileSystem
 
   bake_folder "/home/my_name/work/crystal_project/public"
-  bake_folder "../public"
+  bake_folder "../public", include_dotfiles: true # optionally includes dotfiles
 end
 
 ```
@@ -36,10 +38,9 @@ Files can be loaded using `get` and `get?` class methods.
 
 ```crystal
 file = FileStorage.get("path/to/file.png")
-
 file.gets_to_end  # returns content of file
 file.path         # returns path of file
-file.size         # returns size of original file
+file.size         # returns size of original file
 ```
 
 When try to get missing file, `get` raises a `BakedFileSystem::NoSuchFileError` exception
@@ -51,7 +52,6 @@ begin
 rescue BakedFileSystem::NoSuchFileError
   puts "File #{path} is missing"
 end
-
 FileStorage.get? "missing/file" # => nil
 ```
 

--- a/spec/baked_file_system_spec.cr
+++ b/spec/baked_file_system_spec.cr
@@ -21,6 +21,11 @@ class MutlipleStorage
   end
 end
 
+class StorageWithHidden
+  extend BakedFileSystem
+  bake_folder "./storage", include_dotfiles: true
+end
+
 def read_slice(path)
   File.open(path, "rb") do |io|
     Slice(UInt8).new(io.size).tap do |buf|
@@ -32,6 +37,11 @@ end
 describe BakedFileSystem do
   it "load only files without hidden one" do
     Storage.files.size.should eq(4)
+    Storage.get?(".hidden/hidden_file.txt").should be_nil
+  end
+
+  it "can include hidden files if requested" do
+    StorageWithHidden.get(".hidden/hidden_file.txt").gets_to_end.should eq "should not be included\n"
   end
 
   it "get correct file attributes" do

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -157,8 +157,8 @@ module BakedFileSystem
   macro extended
     @@files = [] of BakedFileSystem::BakedFile
 
-    macro bake_folder(path, dir = __DIR__, allow_empty = false)
-      BakedFileSystem.bake_folder(\{{ path }}, \{{ dir }}, \{{ allow_empty }})
+    macro bake_folder(path, dir = __DIR__, allow_empty = false, include_dotfiles = false)
+      BakedFileSystem.bake_folder(\{{ path }}, \{{ dir }}, \{{ allow_empty }}, \{{ include_dotfiles }})
     end
   end
 
@@ -175,12 +175,12 @@ module BakedFileSystem
   # Bakes all files in *path* into this baked file system.
   # If *path* is relative, it will be based on *dir* which defaults to `__DIR__`.
   # It will raise if there are no files found in *path* unless *allow_empty* is set to `true`.
-  macro bake_folder(path, dir = __DIR__, allow_empty = false)
+  macro bake_folder(path, dir = __DIR__, allow_empty = false, include_dotfiles = false)
     {% raise "BakedFileSystem.load expects `path` to be a StringLiteral." unless path.is_a?(StringLiteral) %}
 
     %files_size_ante = @@files.size
 
-    {{ run("./loader", path, dir) }}
+    {{ run("./loader", path, dir, include_dotfiles) }}
 
     {% unless allow_empty %}
     raise "BakedFileSystem empty: no files in #{File.expand_path({{ path }}, {{ dir }})}" if @@files.size - %files_size_ante == 0

--- a/src/loader.cr
+++ b/src/loader.cr
@@ -1,5 +1,6 @@
 require "./loader/*"
 
 path = File.expand_path(ARGV[0], ARGV[1])
+include_dotfiles = ARGV[2]? == "true"
 
-BakedFileSystem::Loader.load(STDOUT, path)
+BakedFileSystem::Loader.load(STDOUT, path, include_dotfiles)

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -7,7 +7,7 @@ module BakedFileSystem
     class Error < Exception
     end
 
-    def self.load(io, root_path)
+    def self.load(io, root_path, include_dotfiles = false)
       if !File.exists?(root_path)
         raise Error.new "path does not exist: #{root_path}"
       elsif !File.directory?(root_path)
@@ -20,9 +20,8 @@ module BakedFileSystem
 
       result = [] of String
 
-      files = Dir.glob(Path[root_path].to_posix.join("**", "*"))
-                 # Reject hidden entities and directories
-                 .reject { |path| File.directory?(path) || !(path =~ /(\/\..+)/).nil? }
+      files = Dir.glob(Path[root_path].to_posix.join("**", "*"), match_hidden: include_dotfiles)
+                 .reject { |path| File.directory?(path) }
 
       files.each do |path|
         io << "bake_file BakedFileSystem::BakedFile.new(\n"

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -12,7 +12,7 @@ module BakedFileSystem
         raise Error.new "path does not exist: #{root_path}"
       elsif !File.directory?(root_path)
         raise Error.new "path is not a directory: #{root_path}"
-      elsif !File.readable?(root_path)
+      elsif !File::Info.readable?(root_path)
         raise Error.new "path is not readable: #{root_path}"
       end
 

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -20,8 +20,10 @@ module BakedFileSystem
 
       result = [] of String
 
-      files = Dir.glob(Path[root_path].to_posix.join("**", "*"), match_hidden: include_dotfiles)
-                 .reject { |path| File.directory?(path) }
+
+      pattern = Path[root_path].to_posix.join("**", "*").to_s
+      match_opt = include_dotfiles ? File::MatchOptions::DotFiles : File::MatchOptions.glob_default
+      files = Dir.glob(pattern, match: match_opt).reject { |path| File.directory?(path) }
 
       files.each do |path|
         io << "bake_file BakedFileSystem::BakedFile.new(\n"


### PR DESCRIPTION
This PR adds an `include_dotfiles` option to the `bake_folder` macro and loader, allowing users to include hidden files and folders (those starting with a dot) when baking a folder.

- Default is false (backward compatible)
- Loader, macro, runner, and tests updated
- README updated with usage example

Closes #34