### PR TITLE
Add optional uncompressed baking

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ end
 ```
 
 **Options:**
-- `bake_folder(path, dir = __DIR__, allow_empty: false, include_dotfiles: false, include_patterns: nil, exclude_patterns: nil, max_size: nil)` - Bake all files in a directory
+- `bake_folder(path, dir = __DIR__, allow_empty: false, include_dotfiles: false, include_patterns: nil, exclude_patterns: nil, max_size: nil, compress: true)` - Bake all files in a directory
 - `include_dotfiles: true` - Include files/folders starting with `.` (e.g., `.gitignore`)
 - `allow_empty: false` - Raise error if folder is empty
 - `include_patterns: Array(String)` - Include only files matching glob patterns
 - `exclude_patterns: Array(String)` - Exclude files matching glob patterns
-- `max_size: Int64` - Maximum total compressed size in bytes (compilation fails if exceeded)
+- `max_size: Int64` - Maximum total stored size in bytes (compilation fails if exceeded)
+- `compress: false` - Store files as-is instead of gzip-compressing them at compile time
 
 ### File Filtering
 
@@ -124,28 +125,35 @@ file = Assets.get("document.pdf")
 
 file.path          # => "/document.pdf"
 file.size          # => 10240 (original uncompressed size)
-file.compressed?   # => true (all files are automatically compressed)
-file.compressed_size # => 3120 (actual stored size in binary)
+file.compressed?   # => false (true for files such as .gz that are already compressed content)
+file.stored_compressed? # => true (embedded bytes are gzip-compressed for storage)
+file.compressed_size # => 3120 (stored size in binary)
 ```
 
 ### Compression
 
 Files are automatically gzip-compressed at compile time to reduce binary size. This is transparent - reading a file automatically decompresses it.
 
-**Special case:** Files ending in `.gz` are stored compressed as-is (no double compression).
+Set `compress: false` when read performance is more important than binary size:
 
 ```crystal
-# Both work the same - automatic decompression on read
-Assets.get("file.txt").gets_to_end
-Assets.get("file.txt.gz").gets_to_end
+class Assets
+  extend BakedFileSystem
+
+  bake_folder "./public", compress: false
+end
 ```
+
+With compression disabled, `compressed_size` reports the same value as `size`, and `to_slice` returns the original file bytes.
+
+**Special case:** Files ending in `.gz` are stored and read as-is (no double compression).
 
 ### Size Management & Limits
 
 BakedFileSystem automatically reports compilation statistics to help you monitor binary size impact:
 
 ```
-BakedFileSystem: Embedded 42 files (2.3 MB → 890.0 KB compressed, 38.7% ratio)
+BakedFileSystem: Embedded 42 files (2.3 MB → 890.0 KB stored, 38.7% ratio)
 ```
 
 #### Compilation Warnings
@@ -166,7 +174,7 @@ Enforce maximum size limits per folder:
 class Assets
   extend BakedFileSystem
 
-  # Compilation will fail if compressed size exceeds 10 MB
+  # Compilation will fail if stored size exceeds 10 MB
   bake_folder "./images", max_size: 10_485_760  # 10 MB in bytes
 end
 ```

--- a/spec/baked_file_system_spec.cr
+++ b/spec/baked_file_system_spec.cr
@@ -26,6 +26,11 @@ class StorageWithHidden
   bake_folder "./storage", include_dotfiles: true
 end
 
+class StorageWithoutCompression
+  extend BakedFileSystem
+  bake_folder "./storage", compress: false
+end
+
 class EmptyStorage
   extend BakedFileSystem
   bake_folder "./empty_storage", allow_empty: true
@@ -387,6 +392,17 @@ describe BakedFileSystem do
   end
 
   describe "compression edge cases" do
+    it "stores files as raw bytes when compression is disabled" do
+      path = "lorem.txt"
+      file = StorageWithoutCompression.get(path)
+      original_path = File.expand_path(File.join(__DIR__, "storage", path))
+
+      file.compressed?.should be_false
+      file.compressed_size.should eq(file.size)
+      file.to_slice.should eq(read_slice(original_path))
+      file.gets_to_end.should eq(File.read(original_path))
+    end
+
     it "handles .gz files without double compression" do
       # We have string_encoding/interpolation.gz in storage
       file = Storage.get("string_encoding/interpolation.gz")

--- a/spec/loader_spec.cr
+++ b/spec/loader_spec.cr
@@ -117,6 +117,25 @@ describe BakedFileSystem::Loader do
       code.should contain("path:")
       code.should contain("size:")
     end
+
+    it "generates raw file entries when compression is disabled" do
+      test_path = File.expand_path(File.join(__DIR__, "loader_uncompressed_test"))
+      Dir.mkdir_p(test_path)
+      File.write(File.join(test_path, "plain.txt"), "plain text")
+
+      begin
+        output = IO::Memory.new
+        BakedFileSystem::Loader.load(output, test_path, compress: false)
+
+        code = output.to_s
+        code.should contain("compressed:      false")
+        code.should contain("stored_compressed: false")
+        code.should contain("plain text")
+      ensure
+        File.delete(File.join(test_path, "plain.txt")) if File.exists?(File.join(test_path, "plain.txt"))
+        Dir.delete(test_path) if Dir.exists?(test_path)
+      end
+    end
   end
 
   describe "size tracking and reporting" do
@@ -223,7 +242,7 @@ describe BakedFileSystem::Loader::Stats do
 
       io = IO::Memory.new
 
-      # Should raise when compressed size exceeds max_size
+      # Should raise when stored size exceeds max_size
       expect_raises(BakedFileSystem::Loader::Stats::SizeExceededError) do
         stats.report_to(io, 100_i64)
       end

--- a/src/baked_file_system.cr
+++ b/src/baked_file_system.cr
@@ -44,15 +44,15 @@ module BakedFileSystem
   #
   # ## Architecture
   #
-  # Files are stored compressed in the binary's read-only data section as byte slices.
+  # Files are stored in the binary's read-only data section as byte slices.
   # On first access, BakedFile creates:
   #
-  # 1. **Memory IO**: Wraps the compressed byte slice
-  # 2. **Gzip Reader**: Wraps the memory IO for transparent decompression
-  # 3. **Wrapped IO**: Either the memory IO (for .gz files) or gzip reader
+  # 1. **Memory IO**: Wraps the embedded byte slice
+  # 2. **Gzip Reader**: Wraps the memory IO when storage compression is enabled
+  # 3. **Wrapped IO**: Either the memory IO or gzip reader
   #
   # This lazy-loading approach minimizes memory usage:
-  # - Compressed data stays in read-only binary section
+  # - Embedded data stays in read-only binary section
   # - Decompression happens on-demand during read
   # - No heap allocation unless content is explicitly stored
   #
@@ -84,15 +84,20 @@ module BakedFileSystem
     # Returns the size of this virtual file.
     getter size : Int32
 
-    # Returns whether this file is compressed. If not, it is decompressed on read.
+    # Returns whether this file is already compressed content, such as a `.gz` file.
     getter? compressed : Bool
 
-    @closed : Bool = false
+    # Returns whether the embedded bytes are gzip-compressed for storage.
+    getter? stored_compressed : Bool
 
-    def initialize(@path, @size, @compressed, @slice : Bytes)
+    @closed : Bool = false
+    @wrapped_io : IO
+
+    def initialize(@path, @size, @compressed, @slice : Bytes, stored_compressed : Bool? = nil)
       @path = "/" + @path unless @path.starts_with? '/'
+      @stored_compressed = stored_compressed.nil? ? !@compressed : stored_compressed
       @memory_io = IO::Memory.new(@slice)
-      @wrapped_io = compressed? ? @memory_io : Compress::Gzip::Reader.new(@memory_io)
+      @wrapped_io = stored_compressed? ? Compress::Gzip::Reader.new(@memory_io) : @memory_io
     end
 
     def read(slice : Bytes)
@@ -100,9 +105,9 @@ module BakedFileSystem
       @wrapped_io.read(slice)
     end
 
-    # Returns the compressed size of this virtual file.
+    # Returns the stored size of this virtual file.
     #
-    # See `#size` for the real size of the (uncompressed) file.
+    # See `#size` for the real size of the original file.
     def compressed_size
       @slice.bytesize
     end
@@ -149,7 +154,7 @@ module BakedFileSystem
     def rewind
       check_open
       @memory_io.rewind
-      @wrapped_io = compressed? ? @memory_io : Compress::Gzip::Reader.new(@memory_io)
+      reset_wrapped_io
       nil
     end
 
@@ -178,8 +183,12 @@ module BakedFileSystem
       raise IO::Error.new("Closed stream") if @closed
     end
 
-    # Returns a `Bytes` holding the (compressed) content of this virtual file.
-    # This data needs to be extracted using a `Compress::Gzip::Reader` unless `#compressed?` is true.
+    private def reset_wrapped_io
+      @wrapped_io = stored_compressed? ? Compress::Gzip::Reader.new(@memory_io) : @memory_io
+    end
+
+    # Returns a `Bytes` holding the embedded content of this virtual file.
+    # This data needs to be extracted using a `Compress::Gzip::Reader` if `#stored_compressed?` is true.
     def to_slice : Bytes
       @slice
     end
@@ -268,7 +277,7 @@ module BakedFileSystem
     return nil unless template
 
     # Create a new instance to ensure thread safety and independent state
-    BakedFile.new(template.path, template.size, template.compressed?, template.to_slice)
+    BakedFile.new(template.path, template.size, template.compressed?, template.to_slice, template.stored_compressed?)
   end
 
   # Opens a file and yields it to the block, ensuring it's closed afterwards.
@@ -299,8 +308,8 @@ module BakedFileSystem
     @@files = [] of BakedFileSystem::BakedFile
     @@paths = Set(String).new
 
-    macro bake_folder(path, dir = __DIR__, allow_empty = false, include_dotfiles = false, include_patterns = nil, exclude_patterns = nil, max_size = nil)
-      BakedFileSystem.bake_folder(\{{ path }}, \{{ dir }}, \{{ allow_empty }}, \{{ include_dotfiles }}, \{{ include_patterns }}, \{{ exclude_patterns }}, \{{ max_size }})
+    macro bake_folder(path, dir = __DIR__, allow_empty = false, include_dotfiles = false, include_patterns = nil, exclude_patterns = nil, max_size = nil, compress = true)
+      BakedFileSystem.bake_folder(\{{ path }}, \{{ dir }}, \{{ allow_empty }}, \{{ include_dotfiles }}, \{{ include_patterns }}, \{{ exclude_patterns }}, \{{ max_size }}, \{{ compress }})
     end
 
     def self.add_baked_file(file : BakedFileSystem::BakedFile)
@@ -335,8 +344,9 @@ module BakedFileSystem
   # It will raise if there are no files found in *path* unless *allow_empty* is set to `true`.
   # The *include_patterns* parameter accepts an array of glob patterns to include specific files.
   # The *exclude_patterns* parameter accepts an array of glob patterns to exclude specific files.
-  # The *max_size* parameter can be used to enforce a maximum total compressed size limit (in bytes).
-  macro bake_folder(path, dir = __DIR__, allow_empty = false, include_dotfiles = false, include_patterns = nil, exclude_patterns = nil, max_size = nil)
+  # The *max_size* parameter can be used to enforce a maximum total stored size limit (in bytes).
+  # The *compress* parameter can be set to `false` to store files without gzip compression.
+  macro bake_folder(path, dir = __DIR__, allow_empty = false, include_dotfiles = false, include_patterns = nil, exclude_patterns = nil, max_size = nil, compress = true)
     {% raise "BakedFileSystem.load expects `path` to be a StringLiteral." unless path.is_a?(StringLiteral) %}
 
     %files_size_ante = @@files.size
@@ -358,9 +368,9 @@ module BakedFileSystem
         {% json_parts << "\"exclude\":null" %}
       {% end %}
       {% filter_json = "{" + json_parts.join(",") + "}" %}
-      {{ run("./loader", path, dir, include_dotfiles, filter_json, max_size || "nil") }}
+      {{ run("./loader", path, dir, include_dotfiles, filter_json, max_size || "nil", compress) }}
     {% else %}
-      {{ run("./loader", path, dir, include_dotfiles, "nil", max_size || "nil") }}
+      {{ run("./loader", path, dir, include_dotfiles, "nil", max_size || "nil", compress) }}
     {% end %}
 
     {% unless allow_empty %}

--- a/src/loader.cr
+++ b/src/loader.cr
@@ -26,5 +26,6 @@ if ARGV[3]? && ARGV[3] != "nil"
 end
 
 max_size = ARGV[4]? && ARGV[4] != "nil" ? ARGV[4].to_i64 : nil
+compress = ARGV[5]? != "false"
 
-BakedFileSystem::Loader.load(STDOUT, path, include_dotfiles, include_patterns, exclude_patterns, max_size)
+BakedFileSystem::Loader.load(STDOUT, path, include_dotfiles, include_patterns, exclude_patterns, max_size, compress)

--- a/src/loader/loader.cr
+++ b/src/loader/loader.cr
@@ -81,7 +81,7 @@ module BakedFileSystem
       result
     end
 
-    def self.load(io, root_path, include_dotfiles = false, include_patterns : Array(String)? = nil, exclude_patterns : Array(String)? = nil, max_size : Int64? = nil)
+    def self.load(io, root_path, include_dotfiles = false, include_patterns : Array(String)? = nil, exclude_patterns : Array(String)? = nil, max_size : Int64? = nil, compress = true)
       if !File.exists?(root_path)
         raise Error.new "path does not exist: #{root_path}"
       elsif !File.directory?(root_path)
@@ -122,29 +122,32 @@ module BakedFileSystem
         io << "  path:            " << relative_path.dump << ",\n"
         io << "  size:            " << uncompressed_size << ",\n"
         compressed = path.ends_with?("gz")
+        stored_compressed = compress && !compressed
 
         io << "  compressed:      " << compressed << ",\n"
-
-        byte_counter = ByteCounter.new(io)
+        io << "  stored_compressed: " << stored_compressed << ",\n"
 
         File.open(path, "rb") do |file|
           io << "  slice:         \""
+          stored_size = 0_i64
 
-          StringEncoder.open(byte_counter) do |encoder|
-            if compressed
-              IO.copy file, encoder
-            else
-              Compress::Gzip::Writer.open(encoder) do |writer|
+          StringEncoder.open(io) do |encoder|
+            stored_byte_counter = ByteCounter.new(encoder)
+
+            if stored_compressed
+              Compress::Gzip::Writer.open(stored_byte_counter) do |writer|
                 IO.copy file, writer
               end
+            else
+              IO.copy file, stored_byte_counter
             end
 
-            io << "\".to_slice,\n"
+            stored_size = stored_byte_counter.count
           end
-        end
 
-        compressed_size = byte_counter.count
-        stats.add_file(relative_path, uncompressed_size, compressed_size)
+          io << "\".to_slice,\n"
+          stats.add_file(relative_path, uncompressed_size, stored_size)
+        end
 
         io << ")\n"
         io << "\n"

--- a/src/loader/stats.cr
+++ b/src/loader/stats.cr
@@ -31,7 +31,7 @@ module BakedFileSystem
       def report_to(io : IO, max_size_override : Int64? = nil)
         effective_max_size = max_size_override || @max_size
 
-        io.puts "BakedFileSystem: Embedded #{file_count} file#{"s" if file_count != 1} (#{human_size(total_uncompressed)} → #{human_size(total_compressed)} compressed, #{compression_ratio}% ratio)"
+        io.puts "BakedFileSystem: Embedded #{file_count} file#{"s" if file_count != 1} (#{human_size(total_uncompressed)} → #{human_size(total_compressed)} stored, #{compression_ratio}% ratio)"
 
         if large_files.any?
           io.puts ""
@@ -48,7 +48,7 @@ module BakedFileSystem
 
         if total_compressed > effective_max_size
           io.puts ""
-          io.puts "❌  ERROR: Total embedded size (#{human_size(total_compressed)}) exceeds limit (#{human_size(effective_max_size)})"
+          io.puts "❌  ERROR: Total stored size (#{human_size(total_compressed)}) exceeds limit (#{human_size(effective_max_size)})"
           io.puts "    Reduce the number/size of embedded files or increase the limit."
           raise SizeExceededError.new("Total size #{human_size(total_compressed)} exceeds limit #{human_size(effective_max_size)}")
         end


### PR DESCRIPTION
## New Feature

Baked folders can opt out of gzip storage when read performance matters more than binary size.

## Solution

The `bake_folder` macro accepts `compress: false` and passes that choice through the loader so generated file entries can embed raw source bytes. Runtime read behavior now uses a separate `stored_compressed?` flag instead of overloading `compressed?`, which keeps existing `.gz` source-file semantics intact while allowing uncompressed storage for normal files. Size reporting and `max_size` now describe stored bytes, which is the value that matters whether storage is gzip-compressed or raw.

## Review Notes

- `compressed_size` remains the existing API name for compatibility, but docs now describe it as stored size.
- The pre-existing dirty `spec/storage/images/sidekiq.png` change is intentionally not part of this PR.

Resolves https://github.com/schovi/baked_file_system/issues/60